### PR TITLE
Fix single edge multiprocessing

### DIFF
--- a/netgraph/_edge_layout.py
+++ b/netgraph/_edge_layout.py
@@ -875,6 +875,12 @@ def _get_edge_compatibility(edges, node_positions, threshold, processes=None):
     edge_to_segment = {edge : Segment(node_positions[edge[0]], node_positions[edge[1]]) for edge in edges}
 
     pairs = list(itertools.combinations(edges, 2))
+
+    # Short-circuit when there are no edge pairs to compare. This occurs for
+    # example when the graph consists of a single edge.
+    if not pairs:
+        return []
+
     if (processes is None) or (processes <= 1):
         edge_compatibility = []
         for e1, e2 in pairs:
@@ -1053,6 +1059,8 @@ def _get_Fs(edge_to_control_points, k):
 @profile
 def _get_Fe(edge_to_control_points, edge_compatibility, out, processes=None):
     """Compute all electrostatic forces."""
+    if not edge_compatibility:
+        return out
     if (processes is None) or (processes <= 1):
         for e1, e2, compatibility, reverse in edge_compatibility:
             P = edge_to_control_points[e1]

--- a/tests/test_edge_layout.py
+++ b/tests/test_edge_layout.py
@@ -8,7 +8,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from netgraph._main import Graph
-from netgraph._edge_layout import get_bundled_edge_paths
+from netgraph._edge_layout import (
+    get_bundled_edge_paths,
+    _get_edge_compatibility,
+    _initialize_bundled_control_points,
+    _get_Fe,
+)
 from netgraph._utils import _get_point_on_a_circle
 from toy_graphs import star
 
@@ -169,3 +174,31 @@ def test_bundled_edges_processes_one():
     paths_process = get_bundled_edge_paths(edges, node_positions, processes=1)
     for edge in paths_serial:
         assert np.allclose(paths_serial[edge], paths_process[edge])
+
+
+def test_bundled_edges_single_edge_processes_two():
+    edges = [(0, 1)]
+    node_positions = {
+        0: np.array([0, 0]),
+        1: np.array([1, 0]),
+    }
+    paths = get_bundled_edge_paths(edges, node_positions, processes=2)
+    path = paths[(0, 1)]
+    assert np.allclose(path[0], node_positions[0])
+    assert np.allclose(path[-1], node_positions[1])
+
+
+def test_get_edge_compatibility_single_edge_processes_two():
+    edges = [(0, 1)]
+    node_positions = {0: np.array([0, 0]), 1: np.array([1, 0])}
+    compat = _get_edge_compatibility(edges, node_positions, 0.05, processes=2)
+    assert compat == []
+
+
+def test_get_Fe_empty_compatibility_processes_two():
+    edges = [(0, 1)]
+    node_positions = {0: np.array([0, 0]), 1: np.array([1, 0])}
+    cp = _initialize_bundled_control_points(edges, node_positions)
+    out = {(0, 1): np.zeros((2, 2))}
+    res = _get_Fe(cp, [], out.copy(), processes=2)
+    assert np.array_equal(res[(0, 1)], out[(0, 1)])


### PR DESCRIPTION
## Summary
- skip chunking when there's only one edge
- avoid spawning workers when there are no compatible edges
- test short-circuit logic for a single edge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684899d87fe083339fee56f5fb62b54f