### PR TITLE
Fix zero divisions in edge force computation

### DIFF
--- a/netgraph/_edge_layout.py
+++ b/netgraph/_edge_layout.py
@@ -841,7 +841,8 @@ def _Fe_worker(args):
             delta = Q[::-1] - P
 
         distance_squared = delta[:, 0]**2 + delta[:, 1]**2
-        displacement = compatibility * delta / distance_squared[..., None]
+        distance_squared[distance_squared == 0] = 1e-12
+        displacement = compatibility * delta / distance_squared[:, None]
 
         displacement[0] = 0
         displacement[-1] = 0
@@ -1072,7 +1073,8 @@ def _get_Fe(edge_to_control_points, edge_compatibility, out, processes=None):
                 delta = Q[::-1] - P
 
             distance_squared = delta[:, 0]**2 + delta[:, 1]**2
-            displacement = compatibility * delta / distance_squared[..., None]
+            distance_squared[distance_squared == 0] = 1e-12
+            displacement = compatibility * delta / distance_squared[:, None]
 
             displacement[0] = 0
             displacement[-1] = 0


### PR DESCRIPTION
## Summary
- protect against zero divisions when computing electrostatic edge forces
- update `_Fe_worker` and `_get_Fe` to use a small epsilon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a270740083339f659db60e4ccdb6