### PR TITLE
Fix zero norm case in _get_orthogonal_unit_vector

### DIFF
--- a/netgraph/_utils.py
+++ b/netgraph/_utils.py
@@ -357,9 +357,14 @@ def _get_orthogonal_unit_vector(v):
 
     """
 
-    v = v / np.linalg.norm(v, axis=-1)[:, None] # unit vector
+    norm = np.linalg.norm(v, axis=-1, keepdims=True)
+    norm = np.where(norm == 0, 1, norm)
+    v = v / norm                                # unit vector
+
     w = np.c_[-v[:,1], v[:,0]]                  # orthogonal vector
-    w = w / np.linalg.norm(w, axis=-1)[:, None] # orthogonal unit vector
+    norm = np.linalg.norm(w, axis=-1, keepdims=True)
+    norm = np.where(norm == 0, 1, norm)
+    w = w / norm                                # orthogonal unit vector
     return w
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+from netgraph._utils import _get_orthogonal_unit_vector
+
+
+def test_get_orthogonal_unit_vector_zero_input():
+    vec = np.array([[0.0, 0.0]])
+    result = _get_orthogonal_unit_vector(vec)
+    assert np.all(np.isfinite(result))


### PR DESCRIPTION
## Summary
- normalize vectors safely for zero-norm inputs
- add regression test for zero vector normalization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848abe988088333b806557f363e225e

## Summary by Sourcery

Fix zero norm case in _get_orthogonal_unit_vector by substituting zero norms with one before normalization, and add a regression test to ensure finite output for zero-vector inputs.

Bug Fixes:
- Safely handle zero-norm vectors in _get_orthogonal_unit_vector to avoid division by zero during normalization.

Tests:
- Add regression test for zero vector input to verify output remains finite.