### PR TITLE
Expose intra-community layout selection

### DIFF
--- a/tests/test_node_layout.py
+++ b/tests/test_node_layout.py
@@ -262,3 +262,51 @@ def test_community_layout_separation_scaling():
         return np.linalg.norm(centroids[0] - centroids[1])
 
     assert avg_centroid_distance(pos_spread) > avg_centroid_distance(pos_default)
+
+
+def test_community_layout_custom_callable():
+    edges = [
+        (0, 1), (1, 2), (2, 0),
+        (3, 4), (4, 5), (5, 3),
+        (2, 3),
+    ]
+    node_to_community = {
+        0: 0, 1: 0, 2: 0,
+        3: 1, 4: 1, 5: 1,
+    }
+
+    calls = []
+
+    def dummy_layout(subgraph, nodes=None, origin=(0, 0), scale=(1, 1), **kwargs):
+        calls.append(set(nodes))
+        return {node: np.zeros(2) for node in nodes}
+
+    get_community_layout(
+        edges,
+        node_to_community=node_to_community,
+        intra_layout=dummy_layout,
+    )
+
+    assert len(calls) == 2
+    assert set(frozenset(c) for c in calls) == {frozenset({0, 1, 2}), frozenset({3, 4, 5})}
+
+
+def test_community_layout_intra_layout_kwargs():
+    edges = [
+        (0, 1), (1, 2), (2, 0),
+        (3, 4), (4, 5), (5, 3),
+        (2, 3),
+    ]
+    node_to_community = {
+        0: 0, 1: 0, 2: 0,
+        3: 1, 4: 1, 5: 1,
+    }
+
+    pos_default = get_community_layout(edges, node_to_community=node_to_community)
+    pos_short = get_community_layout(
+        edges,
+        node_to_community=node_to_community,
+        intra_layout_kwargs={"total_iterations": 1},
+    )
+
+    assert pos_default.keys() == pos_short.keys()


### PR DESCRIPTION
## Summary
- allow choosing intra-community layout algorithm in `get_community_layout`
- forward arguments to the chosen layout
- test custom callable invocation
- test `intra_layout_kwargs` forwarding

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install networkx igraph`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e207926608333b908eed60924259c

## Summary by Sourcery

Expose intra-community layout customization in get_community_layout by adding parameters to select and configure the layout algorithm for nodes within each community.

New Features:
- Introduce intra_layout parameter to specify the layout routine used within each community.
- Introduce intra_layout_kwargs to forward user-supplied arguments to the intra-community layout function.

Enhancements:
- Extend internal positioning logic to select between built-in FR layout or a user-provided callable and warn on unrecognized options.
- Update get_community_layout docstring to document new parameters.

Tests:
- Add a test to verify that a custom callable is invoked for each community layout.
- Add a test to confirm that intra_layout_kwargs are properly forwarded to the layout function.