### PR TITLE
Add logger and verbosity controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ help(InteractiveGraph)
 help(EditableGraph)
 ```
 
+## Controlling Verbose Output
+
+By default, Netgraph only shows warnings. To get additional
+information about what the library is doing, enable verbose logging:
+
+```python
+import netgraph
+netgraph.enable_verbose()
+```
+
+You can disable it again with `netgraph.disable_verbose()`.
+When verbose logging is enabled, Netgraph reports progress during
+layout computations and graph construction so you can monitor long
+operations.
+
 ## Examples
 
 

--- a/netgraph/__init__.py
+++ b/netgraph/__init__.py
@@ -99,6 +99,27 @@ Examples
 """
 
 __version__ = "4.13.2"
+
+import logging
+
+# configure package logger
+logger = logging.getLogger("netgraph")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+logger.setLevel(logging.WARNING)
+
+
+def enable_verbose():
+    """Enable informative log output."""
+    logger.setLevel(logging.INFO)
+
+
+def disable_verbose():
+    """Disable informative log output."""
+    logger.setLevel(logging.WARNING)
 __author__ = "Paul Brodersen"
 __email__ = "paulbrodersen+netgraph@gmail.com"
 
@@ -169,4 +190,7 @@ __all__ = [
     'InteractiveArcDiagram',
     'MutableArcDiagram',
     'EditableArcDiagram',
+    'logger',
+    'enable_verbose',
+    'disable_verbose',
 ]

--- a/netgraph/_edge_layout.py
+++ b/netgraph/_edge_layout.py
@@ -8,6 +8,8 @@ Edge routing routines.
 import itertools
 import warnings
 import numpy as np
+import logging
+from . import logger
 
 from uuid import uuid4
 from functools import wraps
@@ -540,10 +542,17 @@ def _get_fruchterman_reingold_layout(edges,
 
     temperatures = _get_temperature_decay(initial_temperature, total_iterations)
 
+    logger.info(
+        "Running spring layout with %d iterations", total_iterations
+    )
+
     # --------------------------------------------------------------------------------
     # main loop
 
+    log_interval = max(total_iterations // 10, 1)
     for ii, temperature in enumerate(temperatures):
+        if logger.isEnabledFor(logging.INFO) and (ii % log_interval == 0):
+            logger.info("\titeration %d / %d", ii + 1, total_iterations)
         candidate_positions = _fruchterman_reingold(mobile_positions, fixed_positions,
                                                     mobile_node_sizes, fixed_node_sizes,
                                                     adjacency, temperature, k)

--- a/netgraph/_interactive_variants.py
+++ b/netgraph/_interactive_variants.py
@@ -8,6 +8,7 @@ InteractiveGraph variants.
 import itertools
 import numpy as np
 import matplotlib.pyplot as plt
+from . import logger
 
 from functools import partial
 from matplotlib.patches import Rectangle
@@ -144,7 +145,7 @@ class MutableGraph(InteractiveGraph):
                         self._add_edge((self._nascent_edge.source, node))
                         self._update_edges([(self._nascent_edge.source, node)])
                     else:
-                        print("Edge already exists!")
+                        logger.info("Edge already exists!")
                     self._remove_nascent_edge()
                 else:
                     self._nascent_edge = self._add_nascent_edge(node)
@@ -210,7 +211,7 @@ class MutableGraph(InteractiveGraph):
 
     def _add_node(self, event):
         if event.inaxes != self.ax:
-            print('Position outside of axis limits! Cannot create node.')
+            logger.info('Position outside of axis limits! Cannot create node.')
             return
 
         # create node ID; use smallest unused int
@@ -527,19 +528,19 @@ class EditableGraph(MutableGraph):
         self._currently_writing_annotations = False
         self.fig.canvas.manager.key_press_handler_id \
             = self.fig.canvas.mpl_connect('key_press_event', self.fig.canvas.manager.key_press)
-        print('Finished writing.')
+        logger.info('Finished writing.')
 
 
     def _initiate_writing_labels(self):
         self._currently_writing_labels = True
         self.fig.canvas.mpl_disconnect(self.fig.canvas.manager.key_press_handler_id)
-        print('Initiated writing label(s).')
+        logger.info('Initiated writing label(s).')
 
 
     def _initiate_writing_annotations(self):
         self._currently_writing_annotations = True
         self.fig.canvas.mpl_disconnect(self.fig.canvas.manager.key_press_handler_id)
-        print('Initiated writing annotations(s).')
+        logger.info('Initiated writing annotations(s).')
 
 
     def _edit_labels(self, key):

--- a/netgraph/_main.py
+++ b/netgraph/_main.py
@@ -7,6 +7,7 @@ import warnings
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from . import logger
 
 from uuid import uuid4
 from scipy.spatial import cKDTree
@@ -280,6 +281,8 @@ class BaseGraph(object):
                  ax=None,
                  *args, **kwargs
     ):
+        logger.info("Building graph …")
+
         self.edges = _parse_edge_list(edges)
 
         self.nodes = self._initialize_nodes(nodes)
@@ -314,9 +317,12 @@ class BaseGraph(object):
         # Initialise node and edge layouts.
         self.origin = origin
         self.scale = scale
+
+        logger.info("Computing node layout '%s'", node_layout)
         self.node_positions = self._initialize_node_layout(
             node_layout, node_layout_kwargs, origin, scale, node_size)
 
+        logger.info("Computing edge layout '%s'", edge_layout)
         self.edge_paths, self.edge_layout, self.edge_layout_kwargs = self._initialize_edge_layout(
             edge_layout, edge_layout_kwargs, origin, scale, edge_width)
 
@@ -324,10 +330,12 @@ class BaseGraph(object):
         self.ax = self._initialize_axis(ax)
 
         self.edge_artists = dict()
+        logger.info("Drawing edges")
         self.draw_edges(self.edge_paths, edge_width, edge_color, edge_alpha,
                         edge_zorder, arrows, node_size)
 
         self.node_artists = dict()
+        logger.info("Drawing nodes")
         self.draw_nodes(self.nodes, self.node_positions,
                         node_shape, node_size, node_edge_width,
                         node_color, node_edge_color, node_alpha, node_zorder)
@@ -360,6 +368,8 @@ class BaseGraph(object):
 
         if prettify:
             _make_pretty(self.ax)
+
+        logger.info("Graph ready")
 
 
     def _initialize_nodes(self, nodes):
@@ -1536,7 +1546,7 @@ class ClickableArtists(object):
                 if not event.key in ('control', 'super+??', 'ctrl+??'):
                     self._deselect_all_artists()
         else:
-            print("Warning: clicked outside axis limits!")
+            logger.info("Warning: clicked outside axis limits!")
 
 
     def _toggle_select_artist(self, artist):
@@ -1699,7 +1709,7 @@ class DraggableArtists(SelectableArtists):
                     self._currently_clicking_on_artist = artist
                     break
         else:
-            print("Warning: clicked outside axis limits!")
+            logger.info("Warning: clicked outside axis limits!")
 
 
     def _on_motion(self, event):

--- a/netgraph/_node_layout.py
+++ b/netgraph/_node_layout.py
@@ -8,6 +8,8 @@ Node layout routines.
 import warnings
 import itertools
 import numpy as np
+import logging
+from . import logger
 
 from functools import wraps
 from itertools import combinations, product
@@ -455,10 +457,19 @@ def get_fruchterman_reingold_layout(edges,
 
     temperatures = _get_temperature_decay(initial_temperature, total_iterations)
 
+    logger.info(
+        "Running spring layout with %d iterations", total_iterations
+    )
+
     # --------------------------------------------------------------------------------
     # main loop
 
+    log_interval = max(total_iterations // 10, 1)
     for ii, temperature in enumerate(temperatures):
+        if logger.isEnabledFor(logging.INFO) and (ii % log_interval == 0):
+            logger.info(
+                "\titeration %d / %d", ii + 1, total_iterations
+            )
         candidate_positions = _fruchterman_reingold(mobile_positions, fixed_positions,
                                                     mobile_node_sizes, fixed_node_sizes,
                                                     adjacency, temperature, k)
@@ -1867,8 +1878,8 @@ def get_geometric_layout(edges, edge_length, node_size=0., tol=1e-3, origin=(0, 
     )
 
     if not result.success:
-        print("Warning: could not compute valid node positions for the given edge lengths.")
-        print(f"scipy.optimize.minimize: {result.message}.")
+        logger.warning("Could not compute valid node positions for the given edge lengths.")
+        logger.warning(f"scipy.optimize.minimize: {result.message}.")
 
     node_positions_as_array = result.x.reshape((-1, 2))
     node_positions_as_array = _fit_to_frame(node_positions_as_array, np.array(origin), np.array(scale), pad_by)


### PR DESCRIPTION
## Summary
- implement package-wide logger with helper functions
- switch `print` statements to logger calls
- document how to enable verbose output
- add progress logging for graph initialization and layout algorithms

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install networkx igraph`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e550394c083339d716096bcb1b80e

## Summary by Sourcery

Introduce a package-wide logging system in netgraph with verbosity controls, replace direct print calls with logger calls throughout the codebase, add progress logging for graph construction and layout algorithms, and document how to enable or disable verbose output in the README.

New Features:
- Add a package-level logger and expose enable_verbose() and disable_verbose() functions to control logging verbosity.
- Log progress for graph building, node and edge layout computations, and drawing operations when verbose mode is enabled.

Enhancements:
- Replace existing print statements with logger calls across interactive and layout modules.

Documentation:
- Document how to enable and disable verbose logging in the README.