### PR TITLE
Reduce verbose iteration logging

### DIFF
--- a/netgraph/_edge_layout.py
+++ b/netgraph/_edge_layout.py
@@ -551,8 +551,8 @@ def _get_fruchterman_reingold_layout(edges,
 
     log_interval = max(total_iterations // 10, 1)
     for ii, temperature in enumerate(temperatures):
-        if logger.isEnabledFor(logging.INFO) and (ii % log_interval == 0):
-            logger.info("\titeration %d / %d", ii + 1, total_iterations)
+        if logger.isEnabledFor(logging.DEBUG) and (ii % log_interval == 0):
+            logger.debug("\titeration %d / %d", ii + 1, total_iterations)
         candidate_positions = _fruchterman_reingold(mobile_positions, fixed_positions,
                                                     mobile_node_sizes, fixed_node_sizes,
                                                     adjacency, temperature, k)

--- a/netgraph/_node_layout.py
+++ b/netgraph/_node_layout.py
@@ -466,8 +466,8 @@ def get_fruchterman_reingold_layout(edges,
 
     log_interval = max(total_iterations // 10, 1)
     for ii, temperature in enumerate(temperatures):
-        if logger.isEnabledFor(logging.INFO) and (ii % log_interval == 0):
-            logger.info(
+        if logger.isEnabledFor(logging.DEBUG) and (ii % log_interval == 0):
+            logger.debug(
                 "\titeration %d / %d", ii + 1, total_iterations
             )
         candidate_positions = _fruchterman_reingold(mobile_positions, fixed_positions,


### PR DESCRIPTION
## Summary
- limit iteration logging to DEBUG level to avoid clutter during verbose mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503949f9ac8333bfee18b536868c77

## Summary by Sourcery

Enhancements:
- Log iteration progress at DEBUG level instead of INFO in both node and edge Fruchterman–Reingold layout functions