### PR TITLE
Improve community layout scaling

### DIFF
--- a/tests/test_node_layout.py
+++ b/tests/test_node_layout.py
@@ -310,3 +310,36 @@ def test_community_layout_intra_layout_kwargs():
     )
 
     assert pos_default.keys() == pos_short.keys()
+
+
+def test_community_layout_power_scaling():
+    """Changing ``power`` should modify relative community sizes."""
+
+    # large community with six nodes arranged in a ring
+    big = list(range(6))
+    edges_big = [(i, (i + 1) % 6) for i in range(6)]
+
+    # small community with two nodes
+    small = [6, 7]
+    edges_small = [(6, 7)]
+
+    # one inter-community edge
+    edges = edges_big + edges_small + [(5, 6)]
+
+    node_to_community = {node: 0 for node in big}
+    node_to_community.update({node: 1 for node in small})
+
+    pos_sqrt = get_community_layout(edges, node_to_community=node_to_community)
+    pos_linear = get_community_layout(
+        edges, node_to_community=node_to_community, power=1.0
+    )
+
+    def community_radius(pos, nodes):
+        coords = np.array([pos[n] for n in nodes])
+        centroid = coords.mean(axis=0)
+        return np.max(np.linalg.norm(coords - centroid, axis=1))
+
+    ratio_sqrt = community_radius(pos_sqrt, big) / community_radius(pos_sqrt, small)
+    ratio_linear = community_radius(pos_linear, big) / community_radius(pos_linear, small)
+
+    assert ratio_linear > ratio_sqrt


### PR DESCRIPTION
## Summary
- adjust community layout API to expose the new `power` parameter
- forward the parameter to community size calculation
- add regression test for the power option

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e . -q`
- `pip install -q networkx igraph pytest-mpl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685045146a0883339bda5304456f5572

## Summary by Sourcery

Introduce a `power` parameter to the community layout function to control exponent-based area scaling of communities and add a regression test for it.

New Features:
- Add `power` parameter to `get_community_layout` API to adjust community area scaling exponent.

Enhancements:
- Forward the `power` argument to `_get_community_sizes` and apply exponent scaling when allocating area per community.

Tests:
- Add regression test to verify that varying `power` values affect relative community radii as expected.